### PR TITLE
Add Flask-based prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Stellar Realms
+
+This is a simple prototype for a browser based multiplayer space trading game inspired by the classic Trade Wars 2002.
+
+## Running
+
+Install dependencies and start the development server:
+
+```bash
+pip install flask
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,66 @@
+from flask import Flask, render_template, request, redirect, url_for, jsonify
+from models import GameMap, Player, ships
+import random
+
+app = Flask(__name__)
+
+game_map = GameMap()
+players = {}
+next_player_id = 1
+
+# admin route to reset game
+@app.route('/admin/reset')
+def admin_reset():
+    global game_map, players, next_player_id
+    game_map = GameMap()
+    players = {}
+    next_player_id = 1
+    return 'Game reset.'
+
+# admin interface simple view
+@app.route('/admin')
+def admin_view():
+    return render_template('admin.html', players=players.values())
+
+# register new player
+@app.route('/register', methods=['POST'])
+def register():
+    global next_player_id
+    name = request.form.get('name')
+    stats = {
+        'iron': int(request.form.get('iron', 1)),
+        'heart': int(request.form.get('heart', 1)),
+        'edge': int(request.form.get('edge', 1)),
+        'shadow': int(request.form.get('shadow', 1)),
+        'wits': int(request.form.get('wits', 1)),
+    }
+    ship = ships[0]
+    p = Player(id=next_player_id, name=name, sector_id=0, ship=ship,
+               credits=1000, fuel=ship.fuel_capacity,
+               iron=stats['iron'], heart=stats['heart'], edge=stats['edge'],
+               shadow=stats['shadow'], wits=stats['wits'])
+    players[next_player_id] = p
+    next_player_id += 1
+    return redirect(url_for('index'))
+
+# move player to sector
+@app.route('/move/<int:player_id>/<int:dest>', methods=['POST'])
+def move(player_id, dest):
+    player = players.get(player_id)
+    if not player:
+        return 'Player not found', 404
+    if dest not in game_map.sectors[player.sector_id].connections:
+        return 'Invalid move', 400
+    distance = 1
+    if player.fuel < distance:
+        return 'Out of fuel', 400
+    player.fuel -= distance
+    player.sector_id = dest
+    return 'Moved'
+
+@app.route('/')
+def index():
+    return render_template('index.html', players=players.values(), game_map=game_map)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,85 @@
+import random
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+@dataclass
+class Ship:
+    name: str
+    cost: int
+    cargo: int
+    fuel_capacity: int
+    attack: int
+    defense: int
+
+@dataclass
+class TradePort:
+    prices: Dict[str, int]  # commodity -> price
+
+@dataclass
+class Sector:
+    id: int
+    connections: List[int] = field(default_factory=list)
+    planet: bool = False
+    trade_port: Optional[TradePort] = None
+
+@dataclass
+class Player:
+    id: int
+    name: str
+    sector_id: int
+    ship: Ship
+    credits: int = 0
+    fuel: int = 0
+    iron: int = 1
+    heart: int = 1
+    edge: int = 1
+    shadow: int = 1
+    wits: int = 1
+
+class GameMap:
+    def __init__(self, width: int = 100, height: int = 100):
+        self.width = width
+        self.height = height
+        self.sectors: Dict[int, Sector] = {}
+        self.generate_map()
+
+    def generate_map(self):
+        total = self.width * self.height
+        self.sectors = {i: Sector(id=i) for i in range(total)}
+        ids = list(self.sectors.keys())
+        for sector in self.sectors.values():
+            connect_count = random.randint(1, 4)
+            while len(sector.connections) < connect_count:
+                dest = random.choice(ids)
+                if dest == sector.id:
+                    continue
+                if len(self.sectors[dest].connections) >= 4:
+                    continue
+                if dest not in sector.connections:
+                    sector.connections.append(dest)
+                    self.sectors[dest].connections.append(sector.id)
+
+        # assign planets and trade ports
+        commodities = ["Ore", "Food", "Technology"]
+        for sector in self.sectors.values():
+            if random.random() < 0.1:
+                sector.planet = True
+            if random.random() < 0.1:
+                prices = {c: random.randint(5, 15) for c in commodities}
+                sector.trade_port = TradePort(prices=prices)
+
+ships = [
+    Ship("Trade Freighter", 0, cargo=50, fuel_capacity=100, attack=5, defense=5),
+    Ship("Scout", 1000, cargo=20, fuel_capacity=80, attack=4, defense=4),
+    Ship("Light Fighter", 2000, cargo=10, fuel_capacity=90, attack=7, defense=5),
+    Ship("Heavy Fighter", 4000, cargo=15, fuel_capacity=100, attack=10, defense=8),
+    Ship("Interceptor", 6000, cargo=10, fuel_capacity=110, attack=12, defense=6),
+    Ship("Destroyer", 10000, cargo=30, fuel_capacity=120, attack=15, defense=12),
+    Ship("Cruiser", 15000, cargo=40, fuel_capacity=150, attack=18, defense=15),
+    Ship("Battleship", 20000, cargo=50, fuel_capacity=170, attack=22, defense=18),
+    Ship("Carrier", 25000, cargo=60, fuel_capacity=180, attack=20, defense=20),
+    Ship("Dreadnought", 30000, cargo=70, fuel_capacity=200, attack=25, defense=25),
+    Ship("Science Vessel", 12000, cargo=35, fuel_capacity=140, attack=8, defense=10),
+    Ship("Miner", 8000, cargo=80, fuel_capacity=130, attack=5, defense=7),
+]
+

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 20px; }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head><title>Admin</title></head>
+<body>
+<h1>Admin Interface</h1>
+<a href="/admin/reset">Reset Game</a>
+<h2>Players</h2>
+<ul>
+{% for p in players %}
+    <li>{{ p.id }} - {{ p.name }} Credits: {{ p.credits }}</li>
+{% else %}
+    <li>No players.</li>
+{% endfor %}
+</ul>
+<a href="/">Back</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+    <title>Stellar Realms</title>
+    <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+    <h1>Stellar Realms</h1>
+    <h2>Players</h2>
+    <ul>
+    {% for p in players %}
+        <li>{{ p.id }} - {{ p.name }} (Sector {{ p.sector_id }}, Fuel {{ p.fuel }})</li>
+    {% else %}
+        <li>No players.</li>
+    {% endfor %}
+    </ul>
+
+    <h2>Register New Player</h2>
+    <form action="/register" method="post">
+        Name: <input name="name" />
+        <br />
+        Iron: <input name="iron" type="number" value="1" />
+        Heart: <input name="heart" type="number" value="1" />
+        Edge: <input name="edge" type="number" value="1" />
+        Shadow: <input name="shadow" type="number" value="1" />
+        Wits: <input name="wits" type="number" value="1" />
+        <br />
+        <button type="submit">Create</button>
+    </form>
+
+    <a href="/admin">Admin</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initial Flask app for a simple web space trading game
- random map generation with planets and trade ports
- example templates and static styles
- README with setup instructions

## Testing
- `python3 -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68421acd73f8832a9c5b4a874b28afa6