### PR TITLE
Add simple auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,16 +1,33 @@
-from flask import Flask, render_template, request, redirect, url_for, jsonify
+from flask import Flask, render_template, request, redirect, url_for, session
+from werkzeug.security import generate_password_hash, check_password_hash
 from models import GameMap, Player, ships
 import random
 
 app = Flask(__name__)
+app.secret_key = 'change-me'
+
+ADMIN_PASSWORD = 'admin'
 
 game_map = GameMap()
 players = {}
 next_player_id = 1
 
+# admin login
+@app.route('/admin/login', methods=['GET', 'POST'])
+def admin_login():
+    if request.method == 'POST':
+        password = request.form.get('password')
+        if password == ADMIN_PASSWORD:
+            session['admin'] = True
+            return redirect(url_for('admin_view'))
+        return 'Invalid password', 403
+    return render_template('admin_login.html')
+
 # admin route to reset game
 @app.route('/admin/reset')
 def admin_reset():
+    if not session.get('admin'):
+        return redirect(url_for('admin_login'))
     global game_map, players, next_player_id
     game_map = GameMap()
     players = {}
@@ -20,6 +37,8 @@ def admin_reset():
 # admin interface simple view
 @app.route('/admin')
 def admin_view():
+    if not session.get('admin'):
+        return redirect(url_for('admin_login'))
     return render_template('admin.html', players=players.values())
 
 # register new player
@@ -27,6 +46,7 @@ def admin_view():
 def register():
     global next_player_id
     name = request.form.get('name')
+    password = request.form.get('password')
     stats = {
         'iron': int(request.form.get('iron', 1)),
         'heart': int(request.form.get('heart', 1)),
@@ -36,11 +56,32 @@ def register():
     }
     ship = ships[0]
     p = Player(id=next_player_id, name=name, sector_id=0, ship=ship,
+               password_hash=generate_password_hash(password),
                credits=1000, fuel=ship.fuel_capacity,
                iron=stats['iron'], heart=stats['heart'], edge=stats['edge'],
                shadow=stats['shadow'], wits=stats['wits'])
     players[next_player_id] = p
+    session['player_id'] = next_player_id
     next_player_id += 1
+    return redirect(url_for('index'))
+
+# player login
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        name = request.form.get('name')
+        password = request.form.get('password')
+        for p in players.values():
+            if p.name == name and check_password_hash(p.password_hash, password):
+                session['player_id'] = p.id
+                return redirect(url_for('index'))
+        return 'Invalid credentials', 403
+    return render_template('login.html')
+
+@app.route('/logout')
+def logout():
+    session.pop('player_id', None)
+    session.pop('admin', None)
     return redirect(url_for('index'))
 
 # move player to sector
@@ -60,7 +101,9 @@ def move(player_id, dest):
 
 @app.route('/')
 def index():
-    return render_template('index.html', players=players.values(), game_map=game_map)
+    current = players.get(session.get('player_id'))
+    return render_template('index.html', players=players.values(),
+                           game_map=game_map, current_player=current)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -28,6 +28,7 @@ class Player:
     name: str
     sector_id: int
     ship: Ship
+    password_hash: str
     credits: int = 0
     fuel: int = 0
     iron: int = 1

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,6 +3,7 @@
 <head><title>Admin</title></head>
 <body>
 <h1>Admin Interface</h1>
+<p><a href="/logout">Logout</a></p>
 <a href="/admin/reset">Reset Game</a>
 <h2>Players</h2>
 <ul>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head><title>Admin Login</title></head>
+<body>
+<h1>Admin Login</h1>
+<form method="post">
+    Password: <input name="password" type="password" />
+    <button type="submit">Login</button>
+</form>
+<a href="/">Back</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,9 +15,13 @@
     {% endfor %}
     </ul>
 
+    {% if current_player %}
+        <p>Logged in as {{ current_player.name }} (<a href="/logout">logout</a>)</p>
+    {% else %}
     <h2>Register New Player</h2>
     <form action="/register" method="post">
         Name: <input name="name" />
+        Password: <input name="password" type="password" />
         <br />
         Iron: <input name="iron" type="number" value="1" />
         Heart: <input name="heart" type="number" value="1" />
@@ -27,6 +31,8 @@
         <br />
         <button type="submit">Create</button>
     </form>
+    <a href="/login">Login</a>
+    {% endif %}
 
     <a href="/admin">Admin</a>
 </body>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head><title>Login</title></head>
+<body>
+<h1>Player Login</h1>
+<form method="post">
+    Name: <input name="name" />
+    Password: <input name="password" type="password" />
+    <button type="submit">Login</button>
+</form>
+<a href="/">Back</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add admin login using a single password
- store password hashes for players
- create login and logout routes
- update templates for login/logout flows
- protect admin routes with authentication

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68421cbd5a3c832a89d5f285f1ffa593