### PR TITLE
Implement admin and user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Then open `http://localhost:5000` in your browser.
 
 Players are stored in an SQLite database `stellar_realms.db`. New players
 register with a password and can log in using the form on the front page.
+
+An administrator account is created automatically with username `admin` and
+password `admin`. Access the admin interface via `/admin/login` and use those
+credentials to log in. Only authenticated admin users can view the admin
+dashboard or reset the game.

--- a/database.py
+++ b/database.py
@@ -26,6 +26,19 @@ def init_db():
             wits INTEGER NOT NULL
         )'''
     )
+    c.execute(
+        '''CREATE TABLE IF NOT EXISTS admins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            password TEXT NOT NULL
+        )'''
+    )
+    c.execute('SELECT COUNT(*) FROM admins')
+    if c.fetchone()[0] == 0:
+        c.execute(
+            'INSERT INTO admins (name, password) VALUES (?, ?)',
+            ('admin', hash_password('admin')),
+        )
     conn.commit()
     conn.close()
 
@@ -132,10 +145,20 @@ def verify_credentials(name: str, password: str) -> Player | None:
         )
     return None
 
+
+def verify_admin_credentials(name: str, password: str) -> bool:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT password FROM admins WHERE name=?', (name,))
+    row = c.fetchone()
+    conn.close()
+    return bool(row) and row[0] == hash_password(password)
+
 def reset_db():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute('DROP TABLE IF EXISTS players')
+    c.execute('DROP TABLE IF EXISTS admins')
     conn.commit()
     conn.close()
     init_db()

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -4,6 +4,7 @@
 <body>
 <h1>Admin Interface</h1>
 <a href="/admin/reset">Reset Game</a>
+<a href="/admin/logout" style="margin-left: 10px;">Logout</a>
 <h2>Players</h2>
 <ul>
 {% for p in players %}

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+    <title>Admin Login</title>
+</head>
+<body>
+    <h1>Admin Login</h1>
+    <form action="/admin/login" method="post">
+        Name: <input name="name" />
+        Password: <input name="password" type="password" />
+        <button type="submit">Login</button>
+    </form>
+    <a href="/">Back</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,10 @@
         <button type="submit">Login</button>
     </form>
 
+    <br />
+    {% if session.get('player_id') %}
+    <a href="/logout">Logout</a>
+    {% endif %}
     <a href="/admin">Admin</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add sessions and protect admin routes
- add admin login/logout functionality
- create admin login page
- create admin table with default admin account
- update README with admin login instructions

## Testing
- `python -m py_compile app.py database.py models.py`
- `python app.py` *(fails: Address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68421e83dc04832a9ecc4b1f9f3d7740