### PR TITLE
Add database persistence for sectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Then open `http://localhost:5000` in your browser.
 Players are stored in an SQLite database `stellar_realms.db`. New players
 register with a password and can log in using the form on the front page.
 
+The map's sectors are also persisted in the same database. Each sector is
+numbered and the space lanes connecting them are stored as simple references to
+other sector numbers.
+
 An administrator account is created automatically with username `admin` and
 password `admin`. Access the admin interface via `/admin/login` and use those
 credentials to log in. Only authenticated admin users can view the admin

--- a/models.py
+++ b/models.py
@@ -41,7 +41,15 @@ class GameMap:
         self.width = width
         self.height = height
         self.sectors: Dict[int, Sector] = {}
-        self.generate_map()
+
+        # Delay importing to avoid circular dependency with database module
+        from database import load_sectors, save_sectors
+
+        # Attempt to load sectors from the database; generate a new map if none exist
+        self.sectors = load_sectors()
+        if not self.sectors:
+            self.generate_map()
+            save_sectors(self.sectors)
 
     def generate_map(self):
         total = self.width * self.height


### PR DESCRIPTION
## Summary
- store map sectors in new `sectors` database table
- persist sectors when generating a new `GameMap`
- drop the sectors table on game reset
- document sector persistence in README

## Testing
- `python -m py_compile app.py models.py database.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842213e2554832ab0db321997056808