### PR TITLE
Random starting sector for players

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Then open `http://localhost:5000` in your browser.
 
 Players are stored in an SQLite database `stellar_realms.db`. New players
 register with a password and can log in using the form on the front page.
+When a player registers they are placed in a random sector on the galactic
+map. The database keeps track of each player's current sector, ship, credits,
+any ship upgrades they have installed and the commodities in their cargo hold.
 
 The map's sectors are also persisted in the same database. Each sector is
 numbered and the space lanes connecting them are stored as simple references to

--- a/app.py
+++ b/app.py
@@ -87,9 +87,10 @@ def register():
             'wits': int(request.form.get('wits', 1)),
         }
         ship = ships[0]
-        new_id = create_player(name, password, stats, ship_index=0)
-        p = Player(id=new_id, name=name, sector_id=0, ship=ship,
-                   credits=1000, fuel=ship.fuel_capacity,
+        start_sector = random.choice(list(game_map.sectors.keys()))
+        new_id = create_player(name, password, stats, ship_index=0, sector_id=start_sector)
+        p = Player(id=new_id, name=name, sector_id=start_sector, ship=ship,
+                   credits=1000, fuel=ship.fuel_capacity, upgrades=[], cargo={},
                    iron=stats['iron'], heart=stats['heart'], edge=stats['edge'],
                    shadow=stats['shadow'], wits=stats['wits'])
         players[new_id] = p

--- a/models.py
+++ b/models.py
@@ -30,6 +30,8 @@ class Player:
     ship: Ship
     credits: int = 0
     fuel: int = 0
+    upgrades: List[str] = field(default_factory=list)
+    cargo: Dict[str, int] = field(default_factory=dict)
     iron: int = 1
     heart: int = 1
     edge: int = 1


### PR DESCRIPTION
## Summary
- randomize starting sector when players register
- store ship upgrades and cargo in the player table
- track these new fields in player objects
- document player database changes

## Testing
- `python -m py_compile app.py database.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_684222715c00832a84111315db06717e